### PR TITLE
build: deno deploy에 배포

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,13 @@ deno task db:seed
 deno task dev
 ```
 
-<http://localhost:8000/> 에서 각 엔드포인트에 접근할 수 있습니다.
-
 <video controls>
   <source src="https://github.com/7rd-wanted-pre-onboarding-team-H/w1-social-feed/assets/54838975/ada43f88-38d1-4da2-a9ce-b98eec8eaca3"
   type="video/mp4" />
   <img src="https://github-production-user-asset-6210df.s3.amazonaws.com/54838975/278273835-b589f9c2-975c-456f-a9dd-9715242166bf.png" alt="Fallback Image">
 </video>
 
-<http://localhost:8000/openapi> 에서 Swagger UI를 통해 API 문서를 확인하고 실행할 수 있습니다.
+<http://localhost:8000/> 에서 Swagger UI를 통해 API 문서를 확인하고 실행할 수 있습니다.
 
 [watch-mode]: https://docs.deno.com/runtime/manual/getting_started/command_line_interface#watch-mode
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ deno task db:seed
 deno task dev
 ```
 
-<http://localhost:3000/> 에서 각 엔드포인트에 접근할 수 있습니다.
+<http://localhost:8000/> 에서 각 엔드포인트에 접근할 수 있습니다.
 
 <video controls>
   <source src="https://github.com/7rd-wanted-pre-onboarding-team-H/w1-social-feed/assets/54838975/ada43f88-38d1-4da2-a9ce-b98eec8eaca3"
@@ -42,7 +42,7 @@ deno task dev
   <img src="https://github-production-user-asset-6210df.s3.amazonaws.com/54838975/278273835-b589f9c2-975c-456f-a9dd-9715242166bf.png" alt="Fallback Image">
 </video>
 
-<http://localhost:3000/openapi> 에서 Swagger UI를 통해 API 문서를 확인하고 실행할 수 있습니다.
+<http://localhost:8000/openapi> 에서 Swagger UI를 통해 API 문서를 확인하고 실행할 수 있습니다.
 
 [watch-mode]: https://docs.deno.com/runtime/manual/getting_started/command_line_interface#watch-mode
 

--- a/auth/signup_controller.ts
+++ b/auth/signup_controller.ts
@@ -29,7 +29,7 @@ export const signupController = (db: Kysely<DB>) =>
 					return c.jsonT({ error: "이미 존재하는 사용자입니다." }, 409)
 				}
 
-				const password = await bcrypt.hash(rawPassword)
+				const password = bcrypt.hashSync(rawPassword)
 
 				const { insertId } = await trx.insertInto("user")
 					.values({ name, email, password }).executeTakeFirstOrThrow()

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,7 +1,8 @@
 {
 	"tasks": {
 		"dev": "deno run -A --watch main.ts",
-		"prod": "deno run --allow-read --allow-write --allow-net=0.0.0.0:3000 main.ts",
+		// deno deploy 환경과 동일한 권한으로 실행합니다.
+		"prod": "DB_PATH=':memory:' deno run --allow-read --allow-env --allow-net main.ts",
 		"test:no-check": "deno task test --no-check",
 		"test": "deno test -A --parallel --shuffle --watch",
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -137,7 +137,7 @@ const app = new OpenAPIHono()
 // Swagger UI를 사용합니다. (경로: "/openapi")
 serveOpenapi(app as OpenAPIHono)
 
-Deno.serve({ port: 3000 }, app.fetch)
+Deno.serve(app.fetch)
 
 app.showRoutes()
 ```

--- a/main.ts
+++ b/main.ts
@@ -27,6 +27,6 @@ const app = new OpenAPIHono()
 
 serveOpenapi(app as OpenAPIHono)
 
-Deno.serve({ port: 3000 }, app.fetch)
+Deno.serve(app.fetch)
 
 app.showRoutes()

--- a/main.ts
+++ b/main.ts
@@ -28,7 +28,7 @@ const app = new OpenAPIHono()
 	.route("", postingListController(db))
 	.route("", postingShareController(db))
 
-serveOpenapi(app as OpenAPIHono)
+serveOpenapi(app as OpenAPIHono, { pageUrl: "/", jsonUrl: "/openapi.json" })
 
 Deno.serve(app.fetch)
 

--- a/main.ts
+++ b/main.ts
@@ -9,11 +9,14 @@ import { signupController } from "./auth/mod.ts"
 import { summationController } from "./summation/mod.ts"
 import { kyselyFrom } from "./kysely_from.ts"
 import { ParseJSONResultsPlugin } from "kysely"
+import { seeded } from "./test_utils.ts"
 
-const db = kyselyFrom(
-	Deno.args[0] ?? "test.db",
-	{ plugins: [new ParseJSONResultsPlugin()] },
-)
+const dbPath = Deno.env.get("DB_PATH") ?? Deno.args[0] ?? "test.db"
+
+console.log("DB_PATH", dbPath)
+
+const rawDb = kyselyFrom(dbPath, { plugins: [new ParseJSONResultsPlugin()] })
+const db = dbPath === ":memory:" ? await seeded(rawDb) : rawDb
 
 const app = new OpenAPIHono()
 	.use("*", logger(), prettyJSON())


### PR DESCRIPTION
## 개요

- resolves #21

[deno deploy](https://deno.com/deploy)에 프로젝트를 배포합니다.

## 내용

deno deploy의 제약 조건을 위해 다음을 변경했습니다:

- `bcrypt.hash`를 `bcrypt.hashSync`로 변경 (web workers 미지원)
- `Deno.serve`에서 포트 옵션 제거 (기본 포트 사용)
- 환경변수 `DB_PATH`로 프로그램을 in-memory DB에서 실행 가능하게 변경 (파일 시스템에 쓰기 불가)