### PR TITLE
feat: posting detail 

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -21,7 +21,7 @@
 		"lineWidth": 100,
 		"proseWrap": "never"
 	},
-    "nodeModulesDir": false,
+	"nodeModulesDir": false,
 	"importMap": "./import_map.json",
 	"compilerOptions": {
 		"exactOptionalPropertyTypes": false,

--- a/posting/posting_controller.ts
+++ b/posting/posting_controller.ts
@@ -2,15 +2,21 @@ import type { Kysely } from "kysely"
 import type { DB } from "../types.ts"
 import { OpenAPIHono } from "hono_zod_openapi"
 import { postingListRoute, postingRoute, postingShareRoute } from "./posting_routes.ts"
-import { getPostingList, getSinglePosting, updateShare } from "./posting_data.ts"
+import { getPostingList, getSinglePosting, updateShare, updateViewCount } from "./posting_data.ts"
 import typeUrl from "./typeUrl.json" with { type: "json" }
 
 export const postingController = (db: Kysely<DB>) =>
 	new OpenAPIHono().openapi(postingRoute, async (c) => {
 		const { id } = c.req.valid("param")
 		const posting = await getSinglePosting(db, id)
-
-		return posting ? c.jsonT(posting) : c.jsonT({ error: "Not Found" }, 404)
+		if(posting){
+			const _viewCount = posting.view_count + 1
+			await updateViewCount(db, id, _viewCount)
+			return c.jsonT(posting) 
+		}else{
+			return c.jsonT({ error: "Not Found" }, 404)
+		}
+		
 	})
 
 export const postingListController = (db: Kysely<DB>) =>

--- a/posting/posting_controller.ts
+++ b/posting/posting_controller.ts
@@ -9,14 +9,13 @@ export const postingController = (db: Kysely<DB>) =>
 	new OpenAPIHono().openapi(postingRoute, async (c) => {
 		const { id } = c.req.valid("param")
 		const posting = await getSinglePosting(db, id)
-		if(posting){
+		if (posting) {
 			const _viewCount = posting.view_count + 1
 			await updateViewCount(db, id, _viewCount)
-			return c.jsonT(posting) 
-		}else{
+			return c.jsonT(posting)
+		} else {
 			return c.jsonT({ error: "Not Found" }, 404)
 		}
-		
 	})
 
 export const postingListController = (db: Kysely<DB>) =>

--- a/posting/posting_data.ts
+++ b/posting/posting_data.ts
@@ -16,6 +16,13 @@ export const updateHashtag = (db: Kysely<DB>, id: number) =>
 		.set({ content: "test" })
 		.where("hashtag.id", "=", id)
 
+export const updateViewCount = (db: Kysely<DB>, id: number, _view: number) =>
+	db
+		.updateTable("posting")
+		.set({ view_count: _view })
+		.where("posting.id", "=", id)
+		.executeTakeFirst()
+
 type Query = z.infer<(typeof postingListRoute)["request"]["query"]> & { pageOffset: number }
 
 const getAllPostings = (db: Kysely<DB>) =>

--- a/summation/summation_data.ts
+++ b/summation/summation_data.ts
@@ -5,7 +5,7 @@ import type { SummationSqlOption } from "./summation_controller.ts"
 
 export const getSummation = (
 	db: Kysely<DB>,
-	{ content, dateFormat, start, end, value }: SummationSqlOption,
+	{ content, dateFormat, start, end }: SummationSqlOption,
 ) => {
 	return db.selectFrom("posting")
 		.innerJoin("posting_to_hashtag as post2tag", "posting.id", "post2tag.posting_id")


### PR DESCRIPTION
기능 : 게시글의 정보들을 전부 보여주고 게시글의 view_count 1증가
/postings/detail/{id}
추가된 코드
1. posting_data 에 view_count 증가 시키는 updateViewCount 추가
2. posting_controller에 postingConroller에 기능1 사용해서 view_count증가 시키면서 posting의 정보 반환 
